### PR TITLE
Add host subworkflow orchestration

### DIFF
--- a/activities.py
+++ b/activities.py
@@ -3,7 +3,7 @@ import json
 from temporalio import activity
 
 @activity.defn
-async def run_ansible_task(task_data: dict) -> dict:
+async def run_ansible_task(task_data: dict, host: str) -> dict:
     task_name = task_data.get("name", "ad-hoc-task")
     module = task_data.get("action", {}).get("module", "debug")
     args = task_data.get("action", {}).get("args", {})
@@ -14,9 +14,11 @@ async def run_ansible_task(task_data: dict) -> dict:
     # Commande ansible
     cmd = [
         "ansible",
-        "localhost",
-        "-m", module,
-        "-a", args_cli,
+        host,
+        "-m",
+        module,
+        "-a",
+        args_cli,
         "--connection=local",
     ]
 

--- a/worker.py
+++ b/worker.py
@@ -2,16 +2,19 @@ import asyncio
 from temporalio.client import Client
 from temporalio.worker import Worker
 from activities import run_ansible_task
-from workflow import AnsiblePlaybookWorkflow
+from workflow import AnsiblePlaybookWorkflow, HostWorkflow
 
 async def main():
     # Start client
     client = await Client.connect("temporal-frontend.temporal.svc:7233")
 
     # Run a worker for the workflow
-    worker = Worker(client, task_queue="ansible-tasks", 
-                            workflows=[AnsiblePlaybookWorkflow],
-                            activities=[run_ansible_task])
+    worker = Worker(
+        client,
+        task_queue="ansible-tasks",
+        workflows=[AnsiblePlaybookWorkflow, HostWorkflow],
+        activities=[run_ansible_task],
+    )
     print("Starting worker...")
     await worker.run()
 

--- a/workflow.py
+++ b/workflow.py
@@ -5,20 +5,44 @@ from temporalio import workflow
 from datetime import timedelta
 from activities import run_ansible_task
 
+
+@workflow.defn
+class HostWorkflow:
+    @workflow.run
+    async def run(self, host: str, tasks: list[dict]) -> list[dict]:
+        results = []
+        for task in tasks:
+            result = await workflow.execute_activity(
+                run_ansible_task,
+                task,
+                host,
+                schedule_to_close_timeout=timedelta(minutes=2),
+            )
+            results.append(result)
+        return results
+
+
 @workflow.defn
 class AnsiblePlaybookWorkflow:
     @workflow.run
-    async def run(self, playbook: list[dict]) -> list[dict]:
-        results = []
+    async def run(self, playbook: list[dict]) -> dict[str, list[dict]]:
+        results: dict[str, list[dict]] = {}
         for play in playbook:
-            for task in play.get("tasks", []):
-                print(task)
-                result = await workflow.execute_activity(
-                    run_ansible_task,
-                    task,
-                    schedule_to_close_timeout=timedelta(minutes=2),
+            tasks = play.get("tasks", [])
+            hosts = play.get("hosts", [])
+            hosts_list = (
+                [h.strip() for h in hosts.split(",")]
+                if isinstance(hosts, str)
+                else list(hosts)
+            )
+            for host in hosts_list:
+                res = await workflow.execute_child_workflow(
+                    HostWorkflow.run,
+                    host,
+                    tasks,
+                    id=f"{workflow.info().workflow_id}-{host}",
                 )
-                results.append(result)
+                results[host] = res
         return results
 
 async def main():


### PR DESCRIPTION
## Summary
- refactor activities to take host parameter
- create `HostWorkflow` and execute as child workflow per host
- adjust worker to register host subworkflow

## Testing
- `python -m py_compile activities.py workflow.py worker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9cfe9f588329bf93ba7229c9e5be