### PR TITLE
Implement dynamic activities for playbook tasks

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -3,9 +3,6 @@ import yaml
 from temporalio.client import Client
 from temporalio import workflow
 from datetime import timedelta
-from activities import run_ansible_task
-
-
 
 @workflow.defn
 class HostWorkflow:
@@ -15,9 +12,10 @@ class HostWorkflow:
         tasks: list[dict] = params.get("tasks", [])
         results = []
         for task in tasks:
-            params = {"host": host, "task": task}
+            activity_name = task.get("name") or next(iter(task))
+            params = {"host": host}
             result = await workflow.execute_activity(
-                run_ansible_task,
+                activity_name,
                 params,
                 schedule_to_close_timeout=timedelta(minutes=2),
             )


### PR DESCRIPTION
## Summary
- generate activities at runtime for every playbook task in `worker.py`
- invoke these dynamic activities by name in `HostWorkflow`

## Testing
- `python -m py_compile workflow.py worker.py activities.py`

------
https://chatgpt.com/codex/tasks/task_e_686034da42e48329bd43b2b83a08ae55